### PR TITLE
Fix issue #3 "Cannot assign to read only property 'exports' of object…

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,2 +1,2 @@
 import VueAdsense from './VueAdsense.vue'
-module.exports = VueAdsense
+export default VueAdsense


### PR DESCRIPTION
## EcmaScript 6 support
Now to a require the correct sintax is:

`var VueAdsense = require('vue-adsense').default`

to import nothing change:

`import VueAdsense from 'vue-adsense'`